### PR TITLE
Add support for coverage files across multiple assemblies

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -42,7 +42,10 @@ const renderFile = (file, options) => {
 }
 
 exports.renderFiles = (coverage, options) => {
-  const files = coverage[0].files
+  const files = []
+  coverage.map(coverageEntry => {
+    files.push.apply(files, coverageEntry.files)
+  })
   return files.map(file => {
     return {
       filename: file.file.split(options.relativeTo + '/')[1],


### PR DESCRIPTION
This is so a file page is generated for all files when coverage is recorded for multiple assemblies