### PR TITLE
Fix line hit values of `undefined`.

### DIFF
--- a/lib/transforms.js
+++ b/lib/transforms.js
@@ -66,7 +66,7 @@ const transformJsonCoverage = coverage => {
         stats: [
           {
             name: 'Hits',
-            value: lines[lineNumber]
+            value: method.Lines[lineNumber]
           }
         ]
       }

--- a/test/transforms-spec.js
+++ b/test/transforms-spec.js
@@ -49,7 +49,16 @@ describe('transforms', () => {
     const methods = Object.keys(classObj)
     const method = classObj[methods[1]]
     const lines = Object.keys(method.Lines)
+
     const transformed = transforms.getLines(method)
+
     assert.equal(transformed.length, lines.length)
+
+    transformed.forEach((transformedLine, i) => {
+      const lineNumber = transformedLine.line;
+      const transformedHitCount = transformedLine.stats.find(s => s.name === 'Hits').value;
+      const originalHitCount = method.Lines[lineNumber];
+      assert.equal(transformedHitCount, originalHitCount)
+    });
   })
 })


### PR DESCRIPTION
When running `coverage-viewer` against a Coverlet report, I was getting back `undefined` line hit values. This was causing issues with calculating the line coverage percentage (coverage was always 100% when it should have been less).

The current fixture used to test `transforms.js` has a similar format to a recent coverlet report in my project. The current tests were not testing enough to catch the bug. 

This PR fixes the `undefined` property and includes additional testing to verify transformed format. 